### PR TITLE
properly handle optional props

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 const cache = {};
-export default h =>
-  new Proxy(
+export default h => {
+  const vnodeProps = Object.keys(h("div", {}, "test"));
+  const isVnode = obj => {
+    const keys = Object.keys(obj);
+    return vnodeProps.every(key => keys.includes(key));
+  };
+  return new Proxy(
     {},
     {
       get: (target, name) => cache[name] || (cache[name] = (...args) =>
-        args[0] && typeof args[0] === "object" && !Array.isArray(args[0])
+        typeof args[0] === "object" && !Array.isArray(args[0]) && !isVnode(args[0])
           ? h(name, ...args)
           : h(name, {}, ...args))
     }
   );
+};

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ export default h => {
     {},
     {
       get: (target, name) => cache[name] || (cache[name] = (...args) =>
-        typeof args[0] === "object" && !Array.isArray(args[0]) && !isVnode(args[0])
+        args[0] && typeof args[0] === "object" && !Array.isArray(args[0]) && !isVnode(args[0])
           ? h(name, ...args)
           : h(name, {}, ...args))
     }


### PR DESCRIPTION
Old logic doesn't work if a vnode is the first argument of `h` and isn't wrapped in an array:
```js
const { div } = domz(h)
div(div('hello')) // doesn't work, inner div is set as attributes
div([div('hello')]) // would work
```

This PR is a possible way of fixing this issue. 
Another option is sticking to the old version and making it clear wrapping in an array is required.

**EDIT:** 

Also, what do you think about moving the cache into the function rather than leaving it outside?

The benefit of having it outside like now I guess is that uses across modules will be able to benefit from the cache, downside is that you might get unexpected results in a project that uses multiple vdom libraries with domz. Unlikely but possible.

I matched the code style that was already there (double quoted strings and semicolons), but I noticed you use single quotes and no semis in the demo code. Easy to change either way 👍 